### PR TITLE
Fix hotkeys to only work when window active

### DIFF
--- a/src/client/src/hooks/index.ts
+++ b/src/client/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './usePanZoom';
 export * from './useExportDiagram';
 export * from './useDiagramHistory';
 export * from './useAnalytics';
+export * from './useWindowActive';

--- a/src/client/src/hooks/useWindowActive.ts
+++ b/src/client/src/hooks/useWindowActive.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { api } from '@/lib/electron';
+
+/**
+ * Hook to track whether the window is currently active (visible and focused).
+ * Hotkeys should only be active when the window is active.
+ *
+ * @returns boolean indicating if the window is currently active
+ */
+export function useWindowActive(): boolean {
+  // Start with true since document.hasFocus() should return true on mount
+  const [isWindowActive, setIsWindowActive] = useState(() => {
+    // Check initial focus state
+    return typeof document !== 'undefined' ? document.hasFocus() : true;
+  });
+
+  useEffect(() => {
+    const handleFocus = () => {
+      console.log('[useWindowActive] Window focused');
+      setIsWindowActive(true);
+    };
+
+    const handleBlur = () => {
+      console.log('[useWindowActive] Window blurred');
+      setIsWindowActive(false);
+    };
+
+    // Subscribe to Electron window events
+    const unsubscribeFocus = api.onWindowFocus(handleFocus);
+    const unsubscribeBlur = api.onWindowBlur(handleBlur);
+
+    return () => {
+      unsubscribeFocus();
+      unsubscribeBlur();
+    };
+  }, []);
+
+  return isWindowActive;
+}

--- a/src/client/src/lib/electron.ts
+++ b/src/client/src/lib/electron.ts
@@ -243,6 +243,15 @@ export const api = {
     window.addEventListener('focus', callback);
     return () => window.removeEventListener('focus', callback);
   },
+
+  onWindowBlur(callback: () => void): () => void {
+    if (electronAPI?.onWindowBlur) {
+      return electronAPI.onWindowBlur(callback);
+    }
+    // In browser mode, use native blur event
+    window.addEventListener('blur', callback);
+    return () => window.removeEventListener('blur', callback);
+  },
 };
 
 // Re-export types

--- a/src/electron/ipc/channels.ts
+++ b/src/electron/ipc/channels.ts
@@ -41,6 +41,7 @@ export const IPC_CHANNELS = {
 
   // Window events (main -> renderer)
   WINDOW_FOCUS: 'window:focus',
+  WINDOW_BLUR: 'window:blur',
 } as const;
 
 export type IPCChannel = typeof IPC_CHANNELS[keyof typeof IPC_CHANNELS];

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -56,6 +56,7 @@ export interface ElectronAPI {
 
   // Window event listeners
   onWindowFocus: (callback: () => void) => () => void;
+  onWindowBlur: (callback: () => void) => () => void;
 
   // Platform info
   platform: NodeJS.Platform;
@@ -131,6 +132,11 @@ const electronAPI: ElectronAPI = {
     const handler = () => callback();
     ipcRenderer.on(IPC_CHANNELS.WINDOW_FOCUS, handler);
     return () => ipcRenderer.removeListener(IPC_CHANNELS.WINDOW_FOCUS, handler);
+  },
+  onWindowBlur: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on(IPC_CHANNELS.WINDOW_BLUR, handler);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.WINDOW_BLUR, handler);
   },
 
   // Platform info

--- a/src/electron/window.ts
+++ b/src/electron/window.ts
@@ -129,6 +129,16 @@ export function createMainWindow(preloadPath: string, isDev: boolean, showOnRead
     mainWindow?.webContents.send(IPC_CHANNELS.WINDOW_FOCUS);
   });
 
+  // Notify renderer when window loses focus (for disabling hotkeys)
+  mainWindow.on('blur', () => {
+    mainWindow?.webContents.send(IPC_CHANNELS.WINDOW_BLUR);
+  });
+
+  // Also notify when window is hidden
+  mainWindow.on('hide', () => {
+    mainWindow?.webContents.send(IPC_CHANNELS.WINDOW_BLUR);
+  });
+
   // Load the app
   if (isDev) {
     // Development: load from Vite dev server


### PR DESCRIPTION
Add WINDOW_BLUR IPC event to complement WINDOW_FOCUS, allowing the renderer to track when the window loses focus. Create useWindowActive hook to monitor window focus state and update all keyboard shortcuts to check isWindowActive before triggering.

This ensures hotkeys don't interfere when the user is working in other applications, even if Mindpilot is running in the background.