### PR TITLE
Open history panel when search hotkey pressed

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -291,7 +291,15 @@ export function App() {
         ignoreInputElements: true,
         isEnabled: () => !isEditorFocused && !isRenaming,
         handler: () => {
-          historyPanelMethodsRef.current?.focusSearch();
+          if (isHistoryCollapsed) {
+            historyPanelRef.current?.expand();
+            // Small delay to allow panel to expand before focusing search
+            setTimeout(() => {
+              historyPanelMethodsRef.current?.focusSearch();
+            }, 50);
+          } else {
+            historyPanelMethodsRef.current?.focusSearch();
+          }
         }
       },
       // Mode toggle


### PR DESCRIPTION
When the '/' key is pressed to focus the search bar and the history panel is collapsed, the panel now automatically expands before focusing the search input.