### PR TITLE
Point new users at the mermaid-viewer agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
 > [!TIP]
-> **Prefer something lighter?** The core of Mindpilot is now available as an agent skill — no server, no app, just self-contained interactive HTML: [`npx skills add abrinsmead/skills/mermaid-viewer`](https://github.com/abrinsmead/skills). Works with Claude Code and other agents that support skills. It's the recommended starting point for new users.
+> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills)—no local server needed. It generates a self-contained, interactive Mermaid viewer. Works great with Claude artifacts too.
+>
+> Install with: `npx skills add abrinsmead/skills/mermaid-viewer`
 
 ![Screenshot](https://raw.githubusercontent.com/abrinsmead/mindpilot-mcp/main/mindpilot-mcp-latest.png)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
 > [!TIP]
-> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills)—no local server needed. It generates a self-contained, interactive Mermaid viewer. Works great with Claude artifacts too.
+> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills)—no local server needed. It generates a self-contained, interactive Mermaid viewer. It can generate the diagrams as Claude artifacts too.
 >
 > Install with: `npx skills add abrinsmead/skills/mermaid-viewer`
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
+> [!TIP]
+> **Prefer something lighter?** The core of Mindpilot is now available as an agent skill — no server, no app, just self-contained interactive HTML: [`npx skills add abrinsmead/skills/mermaid-viewer`](https://github.com/abrinsmead/skills). Works with Claude Code and other agents that support skills. It's the recommended starting point for new users.
+
 ![Screenshot](https://raw.githubusercontent.com/abrinsmead/mindpilot-mcp/main/mindpilot-mcp-latest.png)
 
 ## Why Mindpilot?

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
 > [!TIP]
-> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills)—no local server needed. It generates a self-contained, interactive Mermaid viewer. It can generate the diagrams as Claude artifacts too.
+> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills/tree/main/mermaid-viewer)—no local server needed. It generates a self-contained, interactive Mermaid viewer. It can generate the diagrams as Claude artifacts too.
 >
 > Install with: `npx skills add abrinsmead/skills/mermaid-viewer`
 


### PR DESCRIPTION
Adds a soft pointer (GitHub TIP callout) at the top of the README recommending the new [mermaid-viewer agent skill](https://github.com/abrinsmead/skills) as the lightweight starting point. No deprecation — the MCP server remains fully supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXLJQwMwobgawAiZwbQUo5