### PR TITLE
Tighten skill tip wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
 > [!TIP]
-> Mindpilot's core functionality is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills/tree/main/mermaid-viewer)—no local server needed. It generates a self-contained, interactive Mermaid viewer. It can generate the diagrams as Claude artifacts too.
+> Mindpilot is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills/tree/main/mermaid-viewer)—no local server needed. Ask your agent to diagram something and it builds a self-contained, interactive Mermaid viewer you can open in your browser or publish as a Claude artifact.
 >
 > Install with: `npx skills add abrinsmead/skills/mermaid-viewer`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 See through your agent's eyes. Visualize legacy code, inspect complex flows, understand everything.
 
 > [!TIP]
-> Mindpilot is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills/tree/main/mermaid-viewer)—no local server needed. Ask your agent to diagram something and it builds a self-contained, interactive Mermaid viewer you can open in your browser or publish as a Claude artifact.
+> Mindpilot is now available as a lightweight [agent skill](https://github.com/abrinsmead/skills/tree/main/mermaid-viewer)—no local MCP server needed. Ask your agent to diagram something and it builds a self-contained, interactive Mermaid viewer you can open in your browser or publish as a Claude artifact.
 >
 > Install with: `npx skills add abrinsmead/skills/mermaid-viewer`
 


### PR DESCRIPTION
Rewords the skill tip: folds the trigger ("ask your agent to diagram something") and the artifact capability into one flowing sentence, removing the repeated "It generates… It can generate…" construction. Also incorporates the clarifying clause from the unmerged final commit of #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXLJQwMwobgawAiZwbQUo5